### PR TITLE
Fix browser distinction for service messages, fix for issue #7

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,8 @@ var TeamcityReporter = function(baseReporterDecorator) {
   this.TEST_START    = '##teamcity[testStarted name=\'%s\']';
   this.TEST_FAILED   = '##teamcity[testFailed name=\'%s\' message=\'FAILED\' details=\'%s\']';
   this.TEST_END      = '##teamcity[testFinished name=\'%s\' duration=\'%s\']';
-  this.BROWSER_START = '##teamcity[blockOpened name=\'%s\']';
-  this.BROWSER_END   = '##teamcity[blockClosed name=\'%s\']';
+  this.BLOCK_OPENED  = '##teamcity[blockOpened name=\'%s\']';
+  this.BLOCK_CLOSED  = '##teamcity[blockClosed name=\'%s\']';
 
   this.onRunStart = function(browsers) {
     var self = this;
@@ -84,15 +84,21 @@ var TeamcityReporter = function(baseReporterDecorator) {
       if(browserResult.lastSuite) {
         log.push(formatMessage(self.SUITE_END, browserResult.lastSuite));
       }
-      self.write(formatMessage(self.BROWSER_START, browserResult.name));
+      self.write(formatMessage(self.BLOCK_OPENED, browserResult.name));
       self.write(log.join(''));
-      self.write(formatMessage(self.BROWSER_END, browserResult.name));
+      self.write(formatMessage(self.BLOCK_CLOSED, browserResult.name));
     });
   };
 
   this.getLog = function(browser, result) {
     var browserResult = this.browserResults[browser.id];
-    var suiteName = browser.name.concat('-',result.suite.join(' '));
+    var suiteName = browser.name;
+    var moduleName = result.suite.join(' ');
+
+    if(moduleName) {
+      suiteName = moduleName.concat('.', suiteName);
+    }
+
     var log = browserResult.log;
     if(browserResult.lastSuite !== suiteName) {
       if(browserResult.lastSuite) {

--- a/test/reporter.coffee
+++ b/test/reporter.coffee
@@ -36,10 +36,10 @@ describe 'TeamCity reporter', ->
     reporter.write.should.have.been.calledWith('##teamcity[blockOpened name=\'Mosaic\']\n')
     reporter.write.should.have.been.calledWith('##teamcity[blockClosed name=\'Mosaic\']\n')
     reporter.write.should.have.been.calledWith """
-      ##teamcity[testSuiteStarted name=\'Mosaic-Suite 1\']
+      ##teamcity[testSuiteStarted name=\'Suite 1.Mosaic\']
       ##teamcity[testStarted name=\'SampleTest\']
       ##teamcity[testFinished name=\'SampleTest\' duration=\'2\']
-      ##teamcity[testSuiteFinished name=\'Mosaic-Suite 1\']
+      ##teamcity[testSuiteFinished name=\'Suite 1.Mosaic\']
 
     """
     done()

--- a/test/reporter.js
+++ b/test/reporter.js
@@ -38,10 +38,10 @@ describe('TeamCity reporter', function(){
     reporter.onRunComplete([]);
     reporter.write.should.have.been.calledWith('##teamcity[blockOpened name=\'Mosaic\']\n');
     reporter.write.should.have.been.calledWith('##teamcity[blockClosed name=\'Mosaic\']\n');
-    reporter.write.should.have.been.calledWith('##teamcity[testSuiteStarted name=\'Mosaic-Suite 1\']\n\
+    reporter.write.should.have.been.calledWith('##teamcity[testSuiteStarted name=\'Suite 1.Mosaic\']\n\
 ##teamcity[testStarted name=\'SampleTest\']\n\
 ##teamcity[testFinished name=\'SampleTest\' duration=\'2\']\n\
-##teamcity[testSuiteFinished name=\'Mosaic-Suite 1\']\n');
+##teamcity[testSuiteFinished name=\'Suite 1.Mosaic\']\n');
     done();
   });
 


### PR DESCRIPTION
Suggestion on how to fix the service message problem. Test suite name is now combined with the name of the browser. Testsuite name and test name should be unique in Teamcity. Without the browser name in the test suite name things will get confused in teamcity when you are testing with more than one browser.
