### PR TITLE
fix: Escape the build log and display it in a friendlier format.

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ var TeamcityReporter = function(baseReporterDecorator) {
     var testName = result.description;
 
     log.push(formatMessage(this.TEST_START, testName));
-    log.push(formatMessage(this.TEST_FAILED, testName, JSON.stringify(result.log)));
+    log.push(formatMessage(this.TEST_FAILED, testName, result.log.join('\n\n')));
     log.push(formatMessage(this.TEST_END, testName, result.time));
   };
 


### PR DESCRIPTION
There are a couple of issues with how the build log is rendered. First it's not properly TC escaped because [stringify escapes chars (like the new line) before they can be TC escaped](https://github.com/karma-runner/karma-teamcity-reporter/blob/master/index.js#L67). So they show up like this in TC and notifications (Note the new lines are not TC escaped):

```
Error: expected 2 to equal 3\n    at http://localhost:9876/absolute.../expect.js?1381777330000:
99\n    at http://localhost:9876/absolute.../expect.js?1381777330000:203\n    at http://localho
st:9876/absolute.../expect.js?1381777330000:73\n    at http://localhost:9876/base/unit/login-sp
ec.js?1381777330000:12\n    at http://localhost:9876/absolute.../mocha.js?
```

The other issue is that the build log is simply json stringified which is not UI friendly IMO:

```
["Error: expected 1 to equal 2\n    at http://localhost:9876/absolute.../expect.js?138177733000
0:99\n    at http://localhost:9876/absolute.../expect.js?1381777330000:203\n    at http://local
host:9876/absolute.../expect.js?1381777330000:73\n    at http://localhost:9876/base/unit/login-
spec.js?1381777330000:12\n    at http://localhost:9876/absolute.../mocha.js?", "Error: expected
 2 to equal 3\n    at http://localhost:9876/absolute.../expect.js?1381777330000:99\n    at http
://localhost:9876/absolute.../expect.js?1381777330000:203\n    at http://localhost:9876/absolut
e.../expect.js?1381777330000:73\n    at http://localhost:9876/base/unit/login-spec.js?138177733
0000:12\n    at http://localhost:9876/absolute.../mocha.js?"]
```

A fix for both these issues would be to join the build log by two new lines instead of stringifying it. Would end up looking like this in TC and in notifications:

```
Error: expected 1 to equal 2
    at http://localhost:9876/absolute.../expect.js?1381777330000:99
    at http://localhost:9876/absolute.../expect.js?1381777330000:203
    at http://localhost:9876/absolute.../expect.js?1381777330000:73
    at http://localhost:9876/base/unit/login-spec.js?1381777330000:12
    at http://localhost:9876/absolute.../mocha.js?

Error: expected 2 to equal 3
    at http://localhost:9876/absolute.../expect.js?1381777330000:99
    at http://localhost:9876/absolute.../expect.js?1381777330000:203
    at http://localhost:9876/absolute.../expect.js?1381777330000:73
    at http://localhost:9876/base/unit/login-spec.js?1381777330000:12
    at http://localhost:9876/absolute.../mocha.js?
```
