### PR TITLE
Replaced the default adapter with fs.writeSync to make sure all tests are reported

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var util = require('util');
+var fs = require('fs');
 
 var escapeMessage = function (message) {
   if(message === null || message === undefined) {
@@ -29,6 +30,8 @@ var formatMessage = function() {
 
 var TeamcityReporter = function(baseReporterDecorator) {
   baseReporterDecorator(this);
+
+  this.adapters = [fs.writeSync.bind(fs.writeSync, 1)];
 
   this.TEST_IGNORED  = '##teamcity[testIgnored name=\'%s\']';
   this.SUITE_START   = '##teamcity[testSuiteStarted name=\'%s\']';


### PR DESCRIPTION
...before process ends.
This is @kdrvn work which I have simply copy pasted into a pull request for issue #5 - if this work is not accepted, please let me know why, so that I could look into fixing it properly.