### PR TITLE
chore: update eslint to newer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
   "dependencies": {},
   "devDependencies": {
     "chai": "*",
-    "eslint": "^0.23.0",
-    "eslint-config-standard": "^3.3.0",
+    "eslint": "^1.0.0",
+    "eslint-config-standard": "^4.0.0",
+	"eslint-plugin-standard": "^1.2.0",
     "grunt": "^0.4.1",
     "grunt-bump": "^0.3.1",
     "grunt-conventional-changelog": "^1.2.2",


### PR DESCRIPTION
With previous configuration running npm install would install eslint
packages that did not work together.

Closes #28