### PR TITLE
Add flowId to avoid unstable teamcity output

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,16 +18,20 @@ var escapeMessage = function (message) {
     .replace(/\]/g, '|]')
 }
 
-var hashString = function(s) {
-  var hash = 0, i, chr, len;
-  if (s === 0) return hash;
+var hashString = function (s) {
+  var hash = 0
+  var i
+  var chr
+  var len
+  
+  if (s === 0) return hash
   for (i = 0, len = s.length; i < len; i++) {
-    chr   = s.charCodeAt(i);
-    hash  = ((hash << 5) - hash) + chr;
-    hash |= 0; 
+    chr = s.charCodeAt(i)
+    hash = ((hash << 5) - hash) + chr
+    hash |= 0
   }
-  return hash;
-};
+  return hash
+}
 
 var formatMessage = function () {
   var args = Array.prototype.slice.call(arguments)
@@ -57,11 +61,11 @@ var TeamcityReporter = function (baseReporterDecorator) {
   var reporter = this
   var initializeBrowser = function (browser) {
     reporter.browserResults[browser.id] = {
-      name: browser.name,
-      log: [],
-      lastSuite: null,
-	    flowId: "karmaTC" + hashString(browser.name + ((new Date()).getTime())) + browser.id
-    }
+    name: browser.name,
+    log: [],
+    lastSuite: null,
+    flowId: 'karmaTC' + hashString(browser.name + ((new Date()).getTime())) + browser.id
+  }
   }
 
   this.onRunStart = function (browsers) {
@@ -117,11 +121,11 @@ var TeamcityReporter = function (baseReporterDecorator) {
     var browserResult = this.browserResults[browser.id]
     var suiteName = browser.name
     var moduleName = result.suite.join(' ')
-
+    
     if (moduleName) {
       suiteName = moduleName.concat('.', suiteName)
     }
-
+    
     var log = browserResult.log
     if (browserResult.lastSuite !== suiteName) {
       if (browserResult.lastSuite) {
@@ -137,8 +141,8 @@ var TeamcityReporter = function (baseReporterDecorator) {
   this.flushLogs = function (browserResult) {
     while (browserResult.log.length > 0) {
       var line = browserResult.log.shift()
-	    line = line.replace("flowId=''", "flowId='"+browserResult.flowId+"'");
-	  
+      line = line.replace("flowId=''", "flowId='" + browserResult.flowId + "'");
+      
       self.write(line)
       if (browserResult.log.length > 0) {
         self.write(' ')

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ var hashString = function (s) {
   var i
   var chr
   var len
-  
+
   if (s === 0) return hash
   for (i = 0, len = s.length; i < len; i++) {
     chr = s.charCodeAt(i)
@@ -39,7 +39,7 @@ var formatMessage = function () {
   for (var i = args.length - 1; i > 0; i--) {
     args[i] = escapeMessage(args[i])
   }
-  
+
   return util.format.apply(null, args) + '\n'
 }
 
@@ -57,10 +57,10 @@ var TeamcityReporter = function (baseReporterDecorator) {
   this.TEST_END = "##teamcity[testFinished name='%s' duration='%s' flowId=''"
   this.BLOCK_OPENED = "##teamcity[blockOpened name='%s' flowId='']"
   this.BLOCK_CLOSED = "##teamcity[blockClosed name='%s' flowId='']"
-  
+
   var reporter = this
   var initializeBrowser = function (browser) {
-      reporter.browserResults[browser.id] = {
+    reporter.browserResults[browser.id] = {
       name: browser.name,
       log: [],
       lastSuite: null,
@@ -121,11 +121,11 @@ var TeamcityReporter = function (baseReporterDecorator) {
     var browserResult = this.browserResults[browser.id]
     var suiteName = browser.name
     var moduleName = result.suite.join(' ')
-    
+
     if (moduleName) {
       suiteName = moduleName.concat('.', suiteName)
     }
-    
+
     var log = browserResult.log
     if (browserResult.lastSuite !== suiteName) {
       if (browserResult.lastSuite) {
@@ -142,7 +142,7 @@ var TeamcityReporter = function (baseReporterDecorator) {
     while (browserResult.log.length > 0) {
       var line = browserResult.log.shift()
       line = line.replace("flowId=''", "flowId='" + browserResult.flowId + "'")
-      
+
       self.write(line)
       if (browserResult.log.length > 0) {
         self.write(' ')

--- a/index.js
+++ b/index.js
@@ -18,12 +18,24 @@ var escapeMessage = function (message) {
     .replace(/\]/g, '|]')
 }
 
+var hashString = function(s) {
+  var hash = 0, i, chr, len;
+  if (s === 0) return hash;
+  for (i = 0, len = s.length; i < len; i++) {
+    chr   = s.charCodeAt(i);
+    hash  = ((hash << 5) - hash) + chr;
+    hash |= 0; 
+  }
+  return hash;
+};
+
 var formatMessage = function () {
   var args = Array.prototype.slice.call(arguments)
 
   for (var i = args.length - 1; i > 0; i--) {
     args[i] = escapeMessage(args[i])
   }
+  
   return util.format.apply(null, args) + '\n'
 }
 
@@ -33,21 +45,22 @@ var TeamcityReporter = function (baseReporterDecorator) {
 
   this.adapters = [fs.writeSync.bind(fs.writeSync, 1)]
 
-  this.TEST_IGNORED = "##teamcity[testIgnored name='%s']"
-  this.SUITE_START = "##teamcity[testSuiteStarted name='%s']"
-  this.SUITE_END = "##teamcity[testSuiteFinished name='%s']"
-  this.TEST_START = "##teamcity[testStarted name='%s']"
-  this.TEST_FAILED = "##teamcity[testFailed name='%s' message='FAILED' details='%s']"
-  this.TEST_END = "##teamcity[testFinished name='%s' duration='%s']"
-  this.BLOCK_OPENED = "##teamcity[blockOpened name='%s']"
-  this.BLOCK_CLOSED = "##teamcity[blockClosed name='%s']"
-
+  this.TEST_IGNORED = "##teamcity[testIgnored name='%s' flowId='']"
+  this.SUITE_START = "##teamcity[testSuiteStarted name='%s' flowId='']"
+  this.SUITE_END = "##teamcity[testSuiteFinished name='%s' flowId='']"
+  this.TEST_START = "##teamcity[testStarted name='%s' flowId='']"
+  this.TEST_FAILED = "##teamcity[testFailed name='%s' message='FAILED' details='%s' flowId='']"
+  this.TEST_END = "##teamcity[testFinished name='%s' duration='%s' flowId=''"
+  this.BLOCK_OPENED = "##teamcity[blockOpened name='%s' flowId='']"
+  this.BLOCK_CLOSED = "##teamcity[blockClosed name='%s' flowId='']"
+ 
   var reporter = this
   var initializeBrowser = function (browser) {
     reporter.browserResults[browser.id] = {
       name: browser.name,
       log: [],
-      lastSuite: null
+      lastSuite: null,
+	    flowId: "karmaTC" + hashString(browser.name + ((new Date()).getTime())) + browser.id
     }
   }
 
@@ -124,6 +137,8 @@ var TeamcityReporter = function (baseReporterDecorator) {
   this.flushLogs = function (browserResult) {
     while (browserResult.log.length > 0) {
       var line = browserResult.log.shift()
+	    line = line.replace("flowId=''", "flowId='"+browserResult.flowId+"'");
+	  
       self.write(line)
       if (browserResult.log.length > 0) {
         self.write(' ')

--- a/index.js
+++ b/index.js
@@ -57,15 +57,15 @@ var TeamcityReporter = function (baseReporterDecorator) {
   this.TEST_END = "##teamcity[testFinished name='%s' duration='%s' flowId=''"
   this.BLOCK_OPENED = "##teamcity[blockOpened name='%s' flowId='']"
   this.BLOCK_CLOSED = "##teamcity[blockClosed name='%s' flowId='']"
- 
+  
   var reporter = this
   var initializeBrowser = function (browser) {
-    reporter.browserResults[browser.id] = {
-    name: browser.name,
-    log: [],
-    lastSuite: null,
-    flowId: 'karmaTC' + hashString(browser.name + ((new Date()).getTime())) + browser.id
-  }
+      reporter.browserResults[browser.id] = {
+      name: browser.name,
+      log: [],
+      lastSuite: null,
+      flowId: 'karmaTC' + hashString(browser.name + ((new Date()).getTime())) + browser.id
+    }
   }
 
   this.onRunStart = function (browsers) {
@@ -141,7 +141,7 @@ var TeamcityReporter = function (baseReporterDecorator) {
   this.flushLogs = function (browserResult) {
     while (browserResult.log.length > 0) {
       var line = browserResult.log.shift()
-      line = line.replace("flowId=''", "flowId='" + browserResult.flowId + "'");
+      line = line.replace("flowId=''", "flowId='" + browserResult.flowId + "'")
       
       self.write(line)
       if (browserResult.log.length > 0) {

--- a/test/reporter.spec.js
+++ b/test/reporter.spec.js
@@ -18,23 +18,23 @@ describe('TeamCity reporter', function () {
   it('should produce 2 standard messages without browsers', function () {
     reporter.onRunStart([])
     reporter.onRunComplete([])
-    expect(reporter.write).to.have.been.calledWith("##teamcity[blockOpened name='JavaScript Unit Tests']\n")
-    expect(reporter.write).to.have.been.calledWith("##teamcity[blockClosed name='JavaScript Unit Tests']\n")
+    expect(reporter.write).to.have.been.calledWith("##teamcity[blockOpened name='JavaScript Unit Tests' flowId='']\n")
+    expect(reporter.write).to.have.been.calledWith("##teamcity[blockClosed name='JavaScript Unit Tests' flowId='']\n")
   })
 
   it('should produce 2 standard messages without tests', function () {
     reporter.onRunStart([mosaic])
     reporter.onRunComplete([])
-    expect(reporter.write).to.have.been.calledWith("##teamcity[blockOpened name='JavaScript Unit Tests']\n")
-    expect(reporter.write).to.have.been.calledWith("##teamcity[blockClosed name='JavaScript Unit Tests']\n")
+    expect(reporter.write).to.have.been.calledWith("##teamcity[blockOpened name='JavaScript Unit Tests' flowId='']\n")
+    expect(reporter.write).to.have.been.calledWith("##teamcity[blockClosed name='JavaScript Unit Tests' flowId='']\n")
   })
 
   it('should produce messages with one test', function () {
     reporter.onRunStart([mosaic])
     reporter.specSuccess(mosaic, {description: 'SampleTest', time: 2, suite: ['Suite 1']})
     reporter.onRunComplete([])
-    expect(reporter.write).to.have.been.calledWith("##teamcity[blockOpened name='JavaScript Unit Tests']\n")
-    expect(reporter.write).to.have.been.calledWith("##teamcity[blockClosed name='JavaScript Unit Tests']\n")
+    expect(reporter.write).to.have.been.calledWith("##teamcity[blockOpened name='JavaScript Unit Tests' flowId='']\n")
+    expect(reporter.write).to.have.been.calledWith("##teamcity[blockClosed name='JavaScript Unit Tests' flowId='']\n")
     expect(reporter.write).to.have.been.calledWith(
       "##teamcity[testSuiteStarted name='Suite 1.Mosaic']\n"
     )


### PR DESCRIPTION
The teamcity output was sometimes unstable if the karma test were running in parallel with other tests. 

[Teamcity Docu:](https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity#BuildScriptInteractionwithTeamCity-MessageFlowId)
"The flowId is a unique identifier of the messages flow in a build. Flow tracking is necessary, for example, to distinguish separate processes running in parallel. The identifier is a string that should be unique in the scope of individual build."
