### PR TITLE
feat: Add config.teamcityReporter and prependSpecIdInSpecNameEnabled …

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ var formatMessage = function () {
 
 var TeamcityReporter = function (baseReporterDecorator, teamcityReporter) {
   const prependSpecIdInSpecNameEnabled = !!(teamcityReporter && teamcityReporter.prependSpecIdInSpecNameEnabled)
+  const useSpecFullName = !!(teamcityReporter && teamcityReporter.useSpecFullName)
 
   baseReporterDecorator(this)
   var self = this
@@ -67,14 +68,18 @@ var TeamcityReporter = function (baseReporterDecorator, teamcityReporter) {
     }
   }
 
-  const getFormattedSpecName = ({ id, description }) => {
+  const getFormattedSpecName = ({ id, description, fullName }) => {
     let formattedSpecName = ''
 
     if (prependSpecIdInSpecNameEnabled) {
       formattedSpecName += `[${id.toLocaleUpperCase()}] `
     }
 
-    formattedSpecName += description
+    if (useSpecFullName) {
+      formattedSpecName += fullName
+    } else {
+      formattedSpecName += description
+    }
 
     return formattedSpecName
   }

--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ var TeamcityReporter = function (baseReporterDecorator, teamcityReporter) {
     let formattedSpecName = ''
 
     if (prependSpecIdInSpecNameEnabled) {
-        formattedSpecName += `[${id.toLocaleUpperCase()}] `
+      formattedSpecName += `[${id.toLocaleUpperCase()}] `
     }
 
     formattedSpecName += description


### PR DESCRIPTION
…configuration

If a teamcityReporter is defined in the base Karma config with a property prependSpecIdInSpecNameEnabled with its value as true (default behavior is false), then the reporter will prepend the spec id in each spec name. This way spec names are guaranteed to be unique. Addresses karma-runner/karma-teamcity-reporter#99